### PR TITLE
Ignore the .idea folder created by Goland.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,40 @@
 /platformify
+
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+Footer
+© 2023 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+Security
+Status
+Docs
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About
+
+# IDE directories
 .idea


### PR DESCRIPTION
Could be we need more than just this, but [the sample one](https://github.com/github/gitignore/blob/main/Go.gitignore) provided by github is super-simple. 

If you hate this, I can just put it in my global .gitignore too. 