### PR TITLE
Ignore .platform.app.yaml and the .platform/ directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /platformify
 
-.platform.app.yaml
+/.platform.app.yaml
 /.platform/
 
 # If you prefer the allow list template instead of the deny list, see community template:


### PR DESCRIPTION
I apparently pasted more than necessary in the .gitignore file. Also, what it says on the tin. Ignore `.platform.app.yaml` and the `/.platform/` directory in case one of us (that's me) inadvertently creates them in the root directory.