### PR TITLE
Create templates for the Input and Select survey questions.

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -27,5 +27,9 @@ func init() {
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
 	viper.SetEnvPrefix("PLATFORMIFY")
-	viper.AutomaticEnv() // read in environment variables that match
+	viper.AutomaticEnv()        // read in environment variables that match
+	viper.MustBindEnv("COLORS") // white-space separated string. ex: PLATFORMIFY_COLORS=33+hb cyan 247 default
+
+	colors := viper.GetStringSlice("COLORS")
+	setColors(colors...)
 }

--- a/commands/init_colors.go
+++ b/commands/init_colors.go
@@ -1,0 +1,77 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+var (
+	// Colors. See Documentation: https://github.com/mgutz/ansi#style-format
+	color1      = "33"  // DodgerBlue1
+	color2      = "210" // LightCoral
+	color3      = "247" // Grey62
+	color4      = "red" // Red3
+	color5      = "default"
+	colorSchema = []*string{&color1, &color2, &color3, &color4, &color5}
+)
+
+func setColors(colors ...string) {
+	if len(colors) > len(colorSchema) {
+		colors = colors[:len(colorSchema)]
+	}
+	for i, color := range colors {
+		*colorSchema[i] = color
+	}
+
+	survey.InputQuestionTemplate = fmt.Sprintf(`
+{{- color "%[1]s"}}{{ .Message }} {{color "reset"}}
+{{- if .ShowAnswer}}
+	{{- color "%[2]s"}}[{{.Answer}}]{{color "reset"}}{{"\n"}}
+{{ else }}
+	{{- if .Default }}{{color "%[3]s"}}[{{.Default}}] {{color "reset"}}{{ end }}
+{{- end }}`, color1, color2, color3, color4, color5)
+
+	//nolint:lll
+	survey.SelectQuestionTemplate = fmt.Sprintf(`
+{{- define "option"}}
+    {{- if eq .SelectedIndex .CurrentIndex }}{{color "%[2]s" }}{{ .Config.Icons.SelectFocus.Text }} {{else}}{{color "%[5]s"}}  {{end}}
+    {{- .CurrentOpt.Value}}
+    {{- color "reset"}}
+{{end}}
+{{- color "%[1]s"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
+{{- if .ShowAnswer}}{{color "%[2]s"}} [{{.Answer}}]{{color "reset"}}{{"\n"}}{{"\n"}}
+{{- else}}
+  {{- "\n"}}
+  {{- range $ix, $option := .PageEntries}}
+    {{- template "option" $.IterateOption $ix $option}}
+  {{- end}}
+  {{- color "%[3]s"}}Use arrows to move up and down, type to filter{{color "reset"}}{{"\n"}}
+{{- end}}`, color1, color2, color3, color4, color5)
+
+	survey.ConfirmQuestionTemplate = fmt.Sprintf(`
+{{- color "%[1]s"}}{{ .Message }} {{color "reset"}}
+{{- if .Answer}}
+  {{- color "%[2]s"}}[{{.Answer}}]{{color "reset"}}{{"\n"}}
+{{- else }}
+  {{- color "%[3]s"}}{{if .Default}}Press "y" for yes, "n" for no. {{else}}(y/N){{end}}{{color "reset"}}{{"\n"}}
+{{- end}}`, color1, color2, color3, color4, color5)
+
+	//nolint:lll
+	survey.MultiSelectQuestionTemplate = fmt.Sprintf(`
+{{- define "option"}}
+    {{- if eq .SelectedIndex .CurrentIndex }}{{color "%[5]s" }}{{ .Config.Icons.SelectFocus.Text }}{{color "reset"}}{{else}} {{end}}
+    {{- if index .Checked .CurrentOpt.Index }}{{color "%[2]s" }} {{ .Config.Icons.MarkedOption.Text }} {{else}}{{color "%[5]s" }} {{ .Config.Icons.UnmarkedOption.Text }} {{end}}
+    {{- color "reset"}}
+    {{- " "}}{{- if index .Checked .CurrentOpt.Index }}{{color "%[2]s" }}{{else}}{{color "%[5]s" }}{{end}}{{- .CurrentOpt.Value}}{{color "reset"}}
+{{end}}
+{{- color "%[1]s"}}{{ .Message }}{{ .FilterMessage }}{{color "reset"}}
+{{- if .ShowAnswer}}{{color "%[2]s"}} [{{.Answer}}]{{color "reset"}}{{"\n"}}{{"\n"}}
+{{- else }}
+  {{- "\n"}}
+  {{- range $ix, $option := .PageEntries}}
+    {{- template "option" $.IterateOption $ix $option}}
+  {{- end}}
+  {{- color "%[3]s"}}Use arrows to move, space to select, type to filter{{color "reset"}}{{"\n"}}
+{{- end}}`, color1, color2, color3, color4, color5)
+}

--- a/internal/question/stack.go
+++ b/internal/question/stack.go
@@ -21,7 +21,7 @@ func (q *Stack) Ask(ctx context.Context) error {
 	}
 
 	question := &survey.Select{
-		Message: "Choose your stack:",
+		Message: "What Stack is your project using?",
 		Options: models.Stacks.AllTitles(),
 	}
 


### PR DESCRIPTION
To change colors use env variable `PLATFORMIFY_COLORS`.
It contains up to 5 colors separated by whitespaces.
example:
`PLATFORMIFY_COLORS=33+hb cyan 247 default`

Default values: `33 210 247 red default`
This corresponds to the following values respectively: `DodgerBlue1 LightCoral Grey62 Red3 default`

[colors cheat sheet](https://www.ditig.com/256-colors-cheat-sheet)

Closes https://github.com/platformsh/platformify/issues/35

Some examples from my terminals:
<img width="500" alt="Screenshot 2023-04-05 at 11 39 21 AM" src="https://user-images.githubusercontent.com/2077392/230028529-36b9bbd3-f515-455b-bc48-0a564c096abc.png">