### PR TITLE
Add needed mounts when Next.js application

### DIFF
--- a/platformifiers/templates/nextjs/.platform.app.yaml
+++ b/platformifiers/templates/nextjs/.platform.app.yaml
@@ -100,6 +100,17 @@ web:
   {{ end }}
 
 ##########################
+# The size of the persistent disk of the application (in MB).
+disk: 512
+
+# The mounts that will be available to your application when deployed.
+mounts:
+    # NPM caching directory, so it must be writeable.
+    '/.npm':
+        source: local
+        source_path: 'npm'
+
+##########################
 # Services
 
 # The relationships of the application with services or other applications.


### PR DESCRIPTION
Adds the needed /.npm mount when a Next.js application is run with `npx`.

Fix #65
