### PR TITLE
Move existing files check in the beginning

### DIFF
--- a/commands/platformify.go
+++ b/commands/platformify.go
@@ -33,6 +33,7 @@ services, choosing from a variety of stacks or simple runtimes.`,
 		)
 		q := questionnaire.New(
 			&question.WorkingDirectory{},
+			&question.FilesOverwrite{},
 			&question.Welcome{},
 			&question.Stack{},
 			&question.Type{},

--- a/internal/question/files_overwrite.go
+++ b/internal/question/files_overwrite.go
@@ -1,0 +1,75 @@
+package question
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/AlecAivazis/survey/v2"
+
+	"github.com/platformsh/platformify/internal/colors"
+	"github.com/platformsh/platformify/internal/models"
+)
+
+var proprietaryFiles = []string{
+	".environment",
+	".platform.app.yaml",
+	".platform/services.yaml",
+	".platform/routes.yaml",
+	".platform/applications.yaml",
+}
+
+type FilesOverwrite struct{}
+
+func (q *FilesOverwrite) Ask(ctx context.Context) error {
+	answers, ok := models.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	_, stderr, ok := colors.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	existingFiles := make([]string, 0, len(proprietaryFiles))
+	for _, p := range proprietaryFiles {
+		if st, err := os.Stat(filepath.Join(answers.WorkingDirectory, p)); err == nil && !st.IsDir() {
+			existingFiles = append(existingFiles, p)
+		}
+	}
+
+	if len(existingFiles) > 0 {
+		fmt.Fprintln(
+			stderr,
+			colors.Colorize(
+				colors.WarningCode,
+				fmt.Sprintf("You are reconfiguring the project at %s.", answers.WorkingDirectory),
+			),
+		)
+		fmt.Fprintln(
+			stderr,
+			colors.Colorize(
+				colors.WarningCode,
+				"The following Platform.sh files already exist in this directory:",
+			),
+		)
+		for _, p := range existingFiles {
+			fmt.Fprintln(stderr, colors.Colorize(colors.WarningCode, fmt.Sprintf("  - %s", p)))
+		}
+		proceed := false
+		if err := survey.AskOne(&survey.Confirm{
+			Message: "Do you want to overwrite them?",
+			Default: proceed,
+		}, &proceed); err != nil {
+			return err
+		}
+
+		if !proceed {
+			return fmt.Errorf("user aborted")
+		}
+	}
+
+	return nil
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/Masterminds/sprig/v3"
 	"golang.org/x/exp/slices"
 )
@@ -127,31 +126,6 @@ func GetJSONKey(jsonPath []string, filePath string) (value interface{}, ok bool)
 
 // WriteTemplates in the given directory, making sure the user is okay with overwriting existing files
 func WriteTemplates(ctx context.Context, root string, templates map[string]*template.Template, input any) error {
-	existingFiles := make([]string, 0, len(templates))
-	for path := range templates {
-		if st, err := os.Stat(filepath.Join(root, path)); err == nil && !st.IsDir() {
-			existingFiles = append(existingFiles, path)
-		}
-	}
-
-	if len(existingFiles) > 0 {
-		message := "The following files already exist."
-		accept := false
-		for _, path := range existingFiles {
-			message += "\n  * " + path
-		}
-		message += "\n\nDo you want to overwrite them?"
-		question := &survey.Confirm{
-			Message: message,
-		}
-		if err := survey.AskOne(question, &accept); err != nil {
-			return err
-		}
-		if !accept {
-			return fmt.Errorf("aborted by user")
-		}
-	}
-
 	for path, t := range templates {
 		if err := writeTemplate(ctx, filepath.Join(root, path), t, input); err != nil {
 			return err


### PR DESCRIPTION
We now ask the user immediately if they have one of our proprietary files locally if they would like to overwrite them.

Fix #83
