### PR TITLE
Add instructional commands for build hook to match deploy hook, add more comments

### DIFF
--- a/platformifier/templates/generic/.platform.app.yaml
+++ b/platformifier/templates/generic/.platform.app.yaml
@@ -11,6 +11,10 @@ type: "{{ .Type }}"
 ##########################
 # Dependencies
 
+# Installs global dependencies as part of the build process. They’re independent of your app’s dependencies and
+# are available in the PATH during the build process and in the runtime environment. They’re installed before
+# the build hook runs using a package manager for the language.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
 {{ if .Dependencies -}}
 dependencies:
   {{ range $key, $value := .Dependencies -}}
@@ -37,12 +41,14 @@ dependencies:
   {{- end }}
 {{- end }}
 
+# Specifies a default set of build tasks to run. Flavors are language-specific.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#build
 {{ if .BuildFlavor -}}
 build:
   flavor: {{ .BuildFlavor }}
 {{- else -}}
 # build:
-#   flavor: none # Specifies a default set of build tasks to run.
+#   flavor: none
 {{- end }}
 
 ##########################
@@ -70,10 +76,11 @@ variables:
 {{- end }}
 {{- end }}
 
-# The hooks that will be triggered when the package is deployed.
+# Hooks allow you to customize your code/environment as the project moves through the build and deploy stages.
+# More information: https://docs.platform.sh/create-apps/app-reference.html#hooks
 hooks:
-  # The build hook runs after package manager has been downloaded.
-  # No services are available but the disk is writeable.
+  # The build hook is run after any build flavor.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#build-hook
   build: |
     set -eux
     {{ range $step := .BuildSteps }}
@@ -82,10 +89,8 @@ hooks:
     # Add build steps here.
     # echo 'I am a build step'
     {{ end }}
-  # The deploy hook runs after your application has been deployed and started.
-  # Code cannot be modified at this point but the database is available.
-  # The site is not accepting requests while this script runs so keep it
-  # fast.
+  # The deploy hook is run after the app container has been started, but before it has started accepting requests.
+  # More information: https://docs.platform.sh/create-apps/hooks/hooks-comparison.html#deploy-hook
   deploy: |
     set -eux
     {{ range $deploycmd := .DeployCommand }}


### PR DESCRIPTION
Current iteration of `project:init` creates a `.platform.app.yaml` that includes a comment block for the deploy hook. 
But does not include any information for the build hook. 
Suggestion is to add comments for the build hook and have both point to the docs for additional information.

Closes: https://github.com/platformsh/platformify/issues/87