### PR TITLE
Misconfigured passthru: true when using the generic stack with PHP.

### DIFF
--- a/platformifier/templates/generic/.platform.app.yaml
+++ b/platformifier/templates/generic/.platform.app.yaml
@@ -136,8 +136,8 @@ web:
   locations:
     {{ range $key, $value := .Locations -}}
     "{{ $key }}":
-      {{- range $key, $value := $value }}
-      {{ $key }}: {{ $value -}}
+      {{ range $key, $value := $value }}
+      {{- $key }}: {{ if typeIs "string" $value }}{{ quote $value }}{{ else }}{{ $value }}{{ end }}
       {{ end }}
     {{ end -}}
   {{ else }}
@@ -166,9 +166,9 @@ disk: {{ .Disk }}
 mounts:
   {{ range $key, $value := .Mounts -}}
   "{{ $key }}":
-    {{- range $key, $value := $value }}
-    {{ $key }}: "{{ $value -}}"
-    {{- end }}
+    {{ range $key, $value := $value }}
+    {{- $key }}: "{{ $value }}"
+    {{ end }}
   {{ end -}}
 {{- else -}}
 # mounts:
@@ -189,7 +189,7 @@ mounts:
 relationships:
   {{ range $key, $value := .Relationships }}
   {{- $key }}: "{{ $value }}"
-  {{ end }}
+  {{ end -}}
 {{ else }}
 # relationships:
 #   database: "db:postgresql"


### PR DESCRIPTION
For PHP only:

- Look for the `index.php` inside working directory recursively.
- Keep `/index.php` by default if nothing is found.

Closes: https://github.com/platformsh/platformify/issues/76