### PR TITLE
Introduce support for custom node environment using n

### DIFF
--- a/platformifier/templates/generic/.platform.app.yaml
+++ b/platformifier/templates/generic/.platform.app.yaml
@@ -17,10 +17,10 @@ type: "{{ .Type }}"
 # More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
 {{ if .Dependencies -}}
 dependencies:
-  {{ range $key, $value := .Dependencies -}}
-  {{ $key }}:
-    {{ range $key, $value := $value }}
-    {{- $key }}: "{{ $value }}"
+  {{- range $depGroupKey, $depGroupValue := .Dependencies }}
+  {{ $depGroupKey }}:
+    {{ range $key, $value := $depGroupValue }}
+    {{ $key }}: "{{ $value }}"
     {{- end }}
   {{- end }}
 {{ else -}}
@@ -40,7 +40,6 @@ dependencies:
 #     package: 'version'
   {{- end }}
 {{- end }}
-
 # Specifies a default set of build tasks to run. Flavors are language-specific.
 # More information: https://docs.platform.sh/create-apps/app-reference.html#build
 {{ if .BuildFlavor -}}


### PR DESCRIPTION
When the runtime type is different than NodeJS and Yarn or npm is found as a package manager, n and npx are installed so that n can be used to install the correct runtime for the project.

This ends up with the following changes in `.app.platform.yaml`

```diff
diff --git a/.platform.app.yaml b/.platform.app.yaml
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -17,6 +17,8 @@ type: "python:3.11"
 # More information: https://docs.platform.sh/create-apps/app-reference.html#dependencies
 dependencies:
   nodejs:
+    n: "*"
+    npx: "*"
     yarn: "^1.22.0"
 
 # Specifies a default set of build tasks to run. Flavors are language-specific.
@@ -30,6 +32,7 @@ build:
 # Build-time visible variables.
 variables:
   env:
+    N_PREFIX: "/app/.global"
     POETRY_VERSION: "1.4.0"
     POETRY_VIRTUALENVS_IN_PROJECT: "true"
 
@@ -46,6 +49,8 @@ hooks:
     python -m venv /app/.global
     pip install poetry==$POETRY_VERSION
     poetry install
+    n auto
+    hash -r
     yarn
     yarn build
     # Collect static files so that they can be served by Platform.sh
```