### PR TITLE
Fix endpoint for MariaDB and Oracle MySQL

### DIFF
--- a/internal/question/models/answer.go
+++ b/internal/question/models/answer.go
@@ -158,8 +158,9 @@ func getStack(answersStack Stack) platformifier.Stack {
 // getRelationships returns a map of service names to their relationship names.
 func getRelationships(services []Service) map[string]string {
 	endpointRemap := map[string]string{
-		"mariadb":      "mysql",
-		"oracle-mysql": "mysql",
+		"mariadb":         "mysql",
+		"oracle-mysql":    "mysql",
+		"chrome-headless": "http",
 	}
 	relationships := make(map[string]string)
 	for _, service := range services {

--- a/internal/question/models/answer_test.go
+++ b/internal/question/models/answer_test.go
@@ -32,7 +32,7 @@ func Test_getRelationships(t *testing.T) {
 			},
 		},
 		{
-			name: "MariaDB and Oracle",
+			name: "Remapped",
 			args: args{
 				services: []Service{
 					{
@@ -49,36 +49,19 @@ func Test_getRelationships(t *testing.T) {
 							Version: "14",
 						},
 					},
-				},
-			},
-			want: map[string]string{
-				"mariadb":      "mariadb:mysql",
-				"oracle-mysql": "oracle-mysql:mysql",
-			},
-		},
-		{
-			name: "Multiple",
-			args: args{
-				services: []Service{
 					{
-						Name: "mariadb",
+						Name: "chrome-headless",
 						Type: ServiceType{
-							Name:    "mariadb",
+							Name:    "chrome-headless",
 							Version: "14",
 						},
 					},
-					{
-						Name: "redis",
-						Type: ServiceType{
-							Name:    "redis",
-							Version: "6",
-						},
-					},
 				},
 			},
 			want: map[string]string{
-				"mariadb": "mariadb:mysql",
-				"redis":   "redis:redis",
+				"mariadb":         "mariadb:mysql",
+				"oracle-mysql":    "oracle-mysql:mysql",
+				"chrome-headless": "chrome-headless:http",
 			},
 		},
 	}


### PR DESCRIPTION
The "mysql" endpoint is used for MariaDB, MySQL and Oracle MySQL.

Fix #136
