### PR TITLE
Wrap environment variables in quotes

### DIFF
--- a/platformifier/templates/upsun/.environment
+++ b/platformifier/templates/upsun/.environment
@@ -1,28 +1,28 @@
-export RELATIONSHIPS_JSON=$(echo ${{ .Assets.EnvPrefix }}_RELATIONSHIPS | base64 --decode)
+export RELATIONSHIPS_JSON="$(echo ${{ .Assets.EnvPrefix }}_RELATIONSHIPS | base64 --decode)"
 {{- if .Database }}
 
 # Set database environment variables
-export DB_HOST=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Database }}[0].host")
-export DB_PORT=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Database }}[0].port")
-export DB_DATABASE=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Database }}[0].path")
-export DB_USERNAME=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Database }}[0].username")
-export DB_PASSWORD=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Database }}[0].password")
-export DB_CONNECTION=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Database }}[0].scheme")
+export DB_HOST="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].host')"
+export DB_PORT="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].port')"
+export DB_DATABASE="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].path')"
+export DB_USERNAME="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].username')"
+export DB_PASSWORD="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].password')"
+export DB_CONNECTION="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].scheme')"
 export DATABASE_URL="${DB_CONNECTION}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}"
 {{- end -}}
 {{- if .Cache }}
 
 # Set Cache environment variables
-export CACHE_HOST=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Cache }}[0].host")
-export CACHE_PORT=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Cache }}[0].port")
-export CACHE_PASSWORD=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Cache }}[0].password")
-export CACHE_SCHEME=$(echo $RELATIONSHIPS_JSON | jq -r ".{{ .Cache }}[0].scheme")
+export CACHE_HOST="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Cache }}[0].host')"
+export CACHE_PORT="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Cache }}[0].port')"
+export CACHE_PASSWORD="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Cache }}[0].password')"
+export CACHE_SCHEME="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Cache }}[0].scheme')"
 export CACHE_URL="${CACHE_SCHEME}://${CACHE_PASSWORD}@${CACHE_HOST}:${CACHE_PORT}"
 {{- end -}}
 {{- if eq .Cache "redis" }}
 
 # Set Redis environment variables
-export REDIS_URL=$CACHE_URL
+export REDIS_URL="$CACHE_URL"
 {{- end -}}
 {{- if eq .Stack.Name "strapi" }}
 


### PR DESCRIPTION
The .environment file now quotes all environment variables to avoid potential failures

Fix platformsh/cli#97