### PR TITLE
Fix #167: Missing locations root leads to 500 once the app is deployed

### DIFF
--- a/internal/question/locations.go
+++ b/internal/question/locations.go
@@ -27,6 +27,7 @@ func (q *Locations) Ask(ctx context.Context) error {
 		if answers.Type.Runtime == models.PHP {
 			locations := map[string]interface{}{
 				"passthru": "/index.php",
+				"root":     "",
 			}
 			if indexPath := utils.FindFile(answers.WorkingDirectory, "index.php"); indexPath != "" {
 				indexRelPath, _ := filepath.Rel(answers.WorkingDirectory, indexPath)


### PR DESCRIPTION
Now if no `index.php` can be found, `locations.root` defaults to `""`