### PR TITLE
Replace `local` mount source by `storage` for Upsun

### DIFF
--- a/platformifier/templates/upsun/.upsun/config.yaml
+++ b/platformifier/templates/upsun/.upsun/config.yaml
@@ -35,13 +35,14 @@ applications:
       {{ range $key, $value := .Mounts -}}
       "{{ $key }}":
         {{ range $key, $value := $value }}
+        {{- if eq $key "source" -}}{{- $value = $value | replace "local" "storage" -}}{{- end -}}
         {{- $key }}: "{{ $value }}"
         {{ end }}
       {{ end -}}
     {{- else -}}
     # mounts:
-    #   "/.cache": # Represents the path in the app.
-    #     source: "local" # "local" sources are unique to the app, while "service" sources can be shared among apps.
+    #   "/storage": # Represents the path in the app.
+    #     source: "storage" # "storage" sources are unique to the app, but shared among instances of the app. "service" sources can be shared among apps.
     #     source_path: "cache" # The subdirectory within the mounted disk (the source) where the mount should point.
     {{- end }}
 

--- a/platformifier/templates/upsun/.upsun/config.yaml
+++ b/platformifier/templates/upsun/.upsun/config.yaml
@@ -41,9 +41,9 @@ applications:
       {{ end -}}
     {{- else -}}
     # mounts:
-    #   "/storage": # Represents the path in the app.
+    #   "/var/uploads": # Represents the path in the app.
     #     source: "storage" # "storage" sources are unique to the app, but shared among instances of the app. "service" sources can be shared among apps.
-    #     source_path: "cache" # The subdirectory within the mounted disk (the source) where the mount should point.
+    #     source_path: "var/uploads" # The subdirectory within the mounted disk (the source) where the mount should point.
     {{- end }}
 
     # The web key configures the web server running in front of your app.

--- a/validator/schema/platformsh.application.json
+++ b/validator/schema/platformsh.application.json
@@ -57,7 +57,11 @@
         "properties": {
           "source": {
             "type": "string",
-            "title": "The type of mount that will provide the data."
+            "title": "The type of mount that will provide the data.",
+            "enum": [
+              "local",
+              "service"
+            ]
           },
           "source_path": {
             "type": "string",
@@ -343,7 +347,11 @@
             "properties": {
               "source": {
                 "type": "string",
-                "title": "The type of mount that will provide the data."
+                "title": "The type of mount that will provide the data.",
+                "enum": [
+                  "local",
+                  "service"
+                ]
               },
               "source_path": {
                 "type": "string",
@@ -724,7 +732,11 @@
               "properties": {
                 "source": {
                   "type": "string",
-                  "title": "The type of mount that will provide the data."
+                  "title": "The type of mount that will provide the data.",
+                  "enum": [
+                    "local",
+                    "service"
+                  ]
                 },
                 "source_path": {
                   "type": "string",

--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -56,7 +56,11 @@
               "properties": {
                 "source": {
                   "type": "string",
-                  "title": "The type of mount that will provide the data."
+                  "title": "The type of mount that will provide the data.",
+                  "enum": [
+                    "storage",
+                    "service"
+                  ]
                 },
                 "source_path": {
                   "type": "string",
@@ -338,7 +342,11 @@
                   "properties": {
                     "source": {
                       "type": "string",
-                      "title": "The type of mount that will provide the data."
+                      "title": "The type of mount that will provide the data.",
+                      "enum": [
+                        "storage",
+                        "service"
+                      ]
                     },
                     "source_path": {
                       "type": "string",
@@ -715,7 +723,11 @@
                     "properties": {
                       "source": {
                         "type": "string",
-                        "title": "The type of mount that will provide the data."
+                        "title": "The type of mount that will provide the data.",
+                        "enum": [
+                          "storage",
+                          "service"
+                        ]
                       },
                       "source_path": {
                         "type": "string",


### PR DESCRIPTION
`local` mount source is now obsolete in Upsun since mounts are not really "local" anymore (shared among app instances).
It's getting replaced by the `storage` keyword.

Fix #176 