### PR TITLE
Change service names to have dashes only

### DIFF
--- a/.uspun/local/project.yaml
+++ b/.uspun/local/project.yaml
@@ -1,2 +1,0 @@
-id: tw5gby3cqpzoi
-host: api.staging.plat.farm

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ test: generate ## Run unit tests
 
 .PHONY: lint
 lint: ## Run linter
-	command -v golangci-lint >/dev/null || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	command -v golangci-lint >/dev/null || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52
 	golangci-lint run --timeout=10m --verbose
 
 .PHONY: generate

--- a/internal/question/services.go
+++ b/internal/question/services.go
@@ -72,7 +72,7 @@ func (q *Services) Ask(ctx context.Context) error {
 		}
 
 		service := models.Service{
-			Name: strings.ReplaceAll(serviceName.String(), "-", "_"),
+			Name: strings.ReplaceAll(serviceName.String(), "_", "-"),
 			Type: models.ServiceType{
 				Name:    serviceName.String(),
 				Version: versions[0],


### PR DESCRIPTION
Replaces undersores in service names with dashes, so that the network service (and other services) have URL compliant names.

Fix #184 