### PR TITLE
Remove sharp as a Node.js dependency

### DIFF
--- a/internal/question/dependency_manager.go
+++ b/internal/question/dependency_manager.go
@@ -75,7 +75,6 @@ func (q *DependencyManager) Ask(ctx context.Context) error {
 		answers.Dependencies["nodejs"] = map[string]string{"yarn": "^1.22.0"}
 	} else if exists := utils.FileExists(answers.WorkingDirectory, npmLockFileName); exists {
 		answers.DependencyManagers = append(answers.DependencyManagers, models.Npm)
-		answers.Dependencies["nodejs"] = map[string]string{"sharp": "*"}
 	}
 
 	return nil


### PR DESCRIPTION
This dependency was wrongly added in the first place and it is not needed.

Fix #159