### PR TITLE
Override DB_CONNECTION for Ruby adaptor name

### DIFF
--- a/platformifier/templates/generic/.environment
+++ b/platformifier/templates/generic/.environment
@@ -8,6 +8,14 @@ export DB_DATABASE="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].path
 export DB_USERNAME="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].username')"
 export DB_PASSWORD="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].password')"
 export DB_CONNECTION="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].scheme')"
+{{- if eq .Runtime "ruby" }}
+{{- if eq .Database "postgresql" }}
+export DB_CONNECTION="postgresql"
+{{- end }}
+{{- if or (eq .Database "mariadb") (eq .Database "mysql") }}
+export DB_CONNECTION="mysql2"
+{{- end }}
+{{- end }}
 export DATABASE_URL="${DB_CONNECTION}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}"
 {{- end -}}
 {{- if .Cache }}

--- a/platformifier/templates/generic/.environment
+++ b/platformifier/templates/generic/.environment
@@ -7,15 +7,7 @@ export DB_PORT="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].port')"
 export DB_DATABASE="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].path')"
 export DB_USERNAME="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].username')"
 export DB_PASSWORD="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].password')"
-export DB_CONNECTION="$(echo $RELATIONSHIPS_JSON | jq -r '.{{ .Database }}[0].scheme')"
-{{- if eq .Runtime "ruby" }}
-{{- if eq .Database "postgresql" }}
-export DB_CONNECTION="postgresql"
-{{- end }}
-{{- if or (eq .Database "mariadb") (eq .Database "mysql") }}
-export DB_CONNECTION="mysql2"
-{{- end }}
-{{- end }}
+{{ if eq .Database "postgresql" }}export DB_CONNECTION="postgresql"{{ else }}export DB_CONNECTION="${{ .DatabaseUpper }}_SCHEME"{{ end }}
 export DATABASE_URL="${DB_CONNECTION}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_DATABASE}"
 {{- end -}}
 {{- if .Cache }}

--- a/platformifier/templates/upsun/.environment
+++ b/platformifier/templates/upsun/.environment
@@ -4,7 +4,7 @@ export DB_PORT="${{ .DatabaseUpper }}_PORT"
 export DB_PATH="${{ .DatabaseUpper }}_PATH"
 export DB_USERNAME="${{ .DatabaseUpper }}_USERNAME"
 export DB_PASSWORD="${{ .DatabaseUpper }}_PASSWORD"
-export DB_SCHEME="${{ .DatabaseUpper }}_SCHEME"
+{{ if eq .Database "postgresql" }}export DB_SCHEME="postgresql"{{ else }}export DB_SCHEME="${{ .DatabaseUpper }}_SCHEME"{{ end }}
 export DATABASE_URL="${DB_SCHEME}://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_PATH}"
 {{- end -}}
 {{- if eq .Stack.Name "laravel" }}


### PR DESCRIPTION
# why

Ruby on Rails adapter name can be different from the protocol connection resulting on error like:

```
I, [2023-09-27T10:32:25.076395 #370]  INFO -- : Refreshing Gem list                                                                                                          
bundler: failed to load command: unicorn (/app/vendor/bundle/ruby/3.2.0/bin/unicorn)                                                                                         
/app/vendor/bundle/ruby/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require': Could not load the 'pgsql' Active Record adapter.
Ensure that the adapter is spelled correctly in config/database.yml and that you've added the necessary adapter gem to your Gemfile. (LoadError)
```

Trilogy is not widely used yet https://github.blog/2022-08-25-introducing-trilogy-a-new-database-adapter-for-ruby-on-rails/

More info

* https://guides.rubyonrails.org/configuring.html#configuring-a-database
* https://stackoverflow.com/questions/41734593/what-is-the-mysql-database-url-format-to-establish-connection-in-rails

# how

Override DB_CONNECTION for those adapter