### PR TITLE
Fix Find() when / is used as input

### DIFF
--- a/platformifier/fs.go
+++ b/platformifier/fs.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/exp/slices"
 )
@@ -53,6 +54,7 @@ func (f *OSFileSystem) Find(root, name string, firstMatch bool) []string {
 	if root == "" {
 		root = "."
 	}
+	root = strings.TrimPrefix(root, "/")
 	found := make([]string, 0)
 	_ = fs.WalkDir(f.readonly(), root, func(p string, d os.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
This fixes issues with Platformifiers that were looking for relative files, like Laravel and Django

Fix #199
