### PR TITLE
Fix Laravel deploy commands order.

### DIFF
--- a/internal/question/deploy_command.go
+++ b/internal/question/deploy_command.go
@@ -40,8 +40,8 @@ func (q *DeployCommand) Ask(ctx context.Context) error {
 			"mkdir -p storage/framework/sessions",
 			"mkdir -p storage/framework/cache",
 			"mkdir -p storage/framework/views",
-			"php artisan optimize:clear",
 			"php artisan migrate --force",
+			"php artisan optimize:clear",
 		)
 	}
 


### PR DESCRIPTION
If Laravel is configured to use the database for cache storage (default), then it will raise an exception when running `optimize:clear` if the database has not yet been migrated.