### PR TITLE
Use simplified relationships for all services & vendors

### DIFF
--- a/internal/question/models/answer.go
+++ b/internal/question/models/answer.go
@@ -2,10 +2,8 @@ package models
 
 import (
 	"encoding/json"
-	// "fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/platformsh/platformify/platformifier"
 )
@@ -157,12 +155,6 @@ func getStack(answersStack Stack) platformifier.Stack {
 
 // getRelationships returns a map of service names to their relationship names.
 func getRelationships(services []Service) map[string]string {
-	endpointRemap := map[string]string{
-		"mariadb":          "mysql",
-		"oracle-mysql":     "mysql",
-		"chrome-headless":  "http",
-		"redis-persistent": "redis",
-	}
 	relationships := make(map[string]string)
 	for _, service := range services {
 		relationships[service.Name] = ""

--- a/internal/question/models/answer.go
+++ b/internal/question/models/answer.go
@@ -165,11 +165,6 @@ func getRelationships(services []Service) map[string]string {
 	}
 	relationships := make(map[string]string)
 	for _, service := range services {
-		endpoint := strings.Split(service.Type.Name, ":")[0]
-		if remappedEndpoint, ok := endpointRemap[endpoint]; ok {
-			endpoint = remappedEndpoint
-		}
-		// relationships[service.Name] = fmt.Sprintf("%s:%s", service.Name, endpoint)
 		relationships[service.Name] = ""
 	}
 	return relationships

--- a/internal/question/models/answer.go
+++ b/internal/question/models/answer.go
@@ -155,20 +155,23 @@ func getStack(answersStack Stack) platformifier.Stack {
 }
 
 // getRelationships returns a map of service names to their endpoint names.
-func getRelationships(services []Service) map[string]string {
+func getRelationships(services []Service) map[string]platformifier.Relationship {
 	endpointRemap := map[string]string{
 		"mariadb":          "mysql",
 		"oracle-mysql":     "mysql",
 		"chrome-headless":  "http",
 		"redis-persistent": "redis",
 	}
-	relationships := make(map[string]string)
+	relationships := make(map[string]platformifier.Relationship)
 	for _, service := range services {
 		endpoint := strings.Split(service.Type.Name, ":")[0]
 		if remappedEndpoint, ok := endpointRemap[endpoint]; ok {
 			endpoint = remappedEndpoint
 		}
-		relationships[service.Name] = endpoint
+		relationships[service.Name] = platformifier.Relationship{
+			Service:  service.Name,
+			Endpoint: endpoint,
+		}
 	}
 	return relationships
 }

--- a/internal/question/models/answer.go
+++ b/internal/question/models/answer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/platformsh/platformify/platformifier"
 )
@@ -153,11 +154,21 @@ func getStack(answersStack Stack) platformifier.Stack {
 	}
 }
 
-// getRelationships returns a map of service names to their relationship names.
+// getRelationships returns a map of service names to their endpoint names.
 func getRelationships(services []Service) map[string]string {
+	endpointRemap := map[string]string{
+		"mariadb":          "mysql",
+		"oracle-mysql":     "mysql",
+		"chrome-headless":  "http",
+		"redis-persistent": "redis",
+	}
 	relationships := make(map[string]string)
 	for _, service := range services {
-		relationships[service.Name] = ""
+		endpoint := strings.Split(service.Type.Name, ":")[0]
+		if remappedEndpoint, ok := endpointRemap[endpoint]; ok {
+			endpoint = remappedEndpoint
+		}
+		relationships[service.Name] = endpoint
 	}
 	return relationships
 }

--- a/internal/question/models/answer.go
+++ b/internal/question/models/answer.go
@@ -2,7 +2,7 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
+	// "fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -169,7 +169,8 @@ func getRelationships(services []Service) map[string]string {
 		if remappedEndpoint, ok := endpointRemap[endpoint]; ok {
 			endpoint = remappedEndpoint
 		}
-		relationships[service.Name] = fmt.Sprintf("%s:%s", service.Name, endpoint)
+		// relationships[service.Name] = fmt.Sprintf("%s:%s", service.Name, endpoint)
+		relationships[service.Name] = ""
 	}
 	return relationships
 }

--- a/internal/question/models/answer_test.go
+++ b/internal/question/models/answer_test.go
@@ -28,7 +28,7 @@ func Test_getRelationships(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"mysql": "",
+				"mysql": "mysql",
 			},
 		},
 		{
@@ -66,10 +66,10 @@ func Test_getRelationships(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"mariadb":          "",
-				"oracle-mysql":     "",
-				"chrome-headless":  "",
-				"redis-persistent": "",
+				"mariadb":          "mysql",
+				"oracle-mysql":     "mysql",
+				"chrome-headless":  "http",
+				"redis-persistent": "redis",
 			},
 		},
 	}

--- a/internal/question/models/answer_test.go
+++ b/internal/question/models/answer_test.go
@@ -28,7 +28,7 @@ func Test_getRelationships(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"mysql": "mysql:mysql",
+				"mysql": "",
 			},
 		},
 		{
@@ -66,10 +66,10 @@ func Test_getRelationships(t *testing.T) {
 				},
 			},
 			want: map[string]string{
-				"mariadb":          "mariadb:mysql",
-				"oracle-mysql":     "oracle-mysql:mysql",
-				"chrome-headless":  "chrome-headless:http",
-				"redis-persistent": "redis-persistent:redis",
+				"mariadb":          "",
+				"oracle-mysql":     "",
+				"chrome-headless":  "",
+				"redis-persistent": "",
 			},
 		},
 	}

--- a/internal/question/models/answer_test.go
+++ b/internal/question/models/answer_test.go
@@ -3,6 +3,8 @@ package models
 import (
 	"reflect"
 	"testing"
+
+	"github.com/platformsh/platformify/platformifier"
 )
 
 func Test_getRelationships(t *testing.T) {
@@ -12,7 +14,7 @@ func Test_getRelationships(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want map[string]string
+		want map[string]platformifier.Relationship
 	}{
 		{
 			name: "Simple",
@@ -27,8 +29,8 @@ func Test_getRelationships(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]string{
-				"mysql": "mysql",
+			want: map[string]platformifier.Relationship{
+				"mysql": {Service: "mysql", Endpoint: "mysql"},
 			},
 		},
 		{
@@ -65,11 +67,11 @@ func Test_getRelationships(t *testing.T) {
 					},
 				},
 			},
-			want: map[string]string{
-				"mariadb":          "mysql",
-				"oracle-mysql":     "mysql",
-				"chrome-headless":  "http",
-				"redis-persistent": "redis",
+			want: map[string]platformifier.Relationship{
+				"mariadb":          {Service: "mariadb", Endpoint: "mysql"},
+				"oracle-mysql":     {Service: "oracle-mysql", Endpoint: "mysql"},
+				"chrome-headless":  {Service: "chrome-headless", Endpoint: "http"},
+				"redis-persistent": {Service: "redis-persistent", Endpoint: "redis"},
 			},
 		},
 	}

--- a/platformifier/models.go
+++ b/platformifier/models.go
@@ -51,6 +51,11 @@ func (s Stack) Name() string {
 	}
 }
 
+type Relationship struct {
+	Service  string
+	Endpoint string
+}
+
 // UserInput contains the configuration from user input.
 type UserInput struct {
 	Stack              Stack
@@ -71,7 +76,7 @@ type UserInput struct {
 	Disk               string
 	Mounts             map[string]map[string]string
 	Services           []Service
-	Relationships      map[string]string
+	Relationships      map[string]Relationship
 	WorkingDirectory   string
 	HasGit             bool
 }

--- a/platformifier/platformifier_test.go
+++ b/platformifier/platformifier_test.go
@@ -72,9 +72,9 @@ var (
 				"source_path": "pip",
 			},
 		},
-		Relationships: map[string]string{
-			"db":    "postgresql",
-			"mysql": "mysql",
+		Relationships: map[string]Relationship{
+			"db":    {Service: "db", Endpoint: "postgresql"},
+			"mysql": {Service: "mysql", Endpoint: "mysql"},
 		},
 		HasGit: true,
 		Services: []Service{
@@ -123,8 +123,8 @@ var (
 				"source_path": "maven",
 			},
 		},
-		Relationships: map[string]string{
-			"mysql": "mysql",
+		Relationships: map[string]Relationship{
+			"mysql": {Service: "mysql", Endpoint: "mysql"},
 		},
 		HasGit: true,
 		Services: []Service{
@@ -157,7 +157,7 @@ var (
 		Dependencies:  map[string]map[string]string{},
 		Disk:          "",
 		Mounts:        map[string]map[string]string{},
-		Relationships: map[string]string{},
+		Relationships: map[string]Relationship{},
 		HasGit:        false,
 		Services:      []Service{},
 	}

--- a/platformifier/platformifier_test.go
+++ b/platformifier/platformifier_test.go
@@ -74,8 +74,8 @@ var (
 			},
 		},
 		Relationships: map[string]string{
-			"db":    "db:postgresql",
-			"mysql": "mysql:mysql",
+			"db":    "",
+			"mysql": "",
 		},
 		HasGit: true,
 		Services: []Service{
@@ -125,7 +125,7 @@ var (
 			},
 		},
 		Relationships: map[string]string{
-			"mysql": "mysql:mysql",
+			"mysql": "",
 		},
 		HasGit: true,
 		Services: []Service{

--- a/platformifier/platformifier_test.go
+++ b/platformifier/platformifier_test.go
@@ -3,7 +3,6 @@ package platformifier
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"reflect"
@@ -574,8 +573,6 @@ func TestPlatformifier_Upsunify(t *testing.T) {
 			if err := validator.ValidateConfig(dir, "upsun"); (err != nil) != tt.wantErr {
 				t.Errorf("Platformifier.Platformify() validation error = %v, wantErr %v", err, tt.wantErr)
 			}
-			out, _ := os.ReadFile(dir + "/.upsun/config.yaml")
-			fmt.Println(string(out))
 		})
 	}
 }

--- a/platformifier/platformifier_test.go
+++ b/platformifier/platformifier_test.go
@@ -73,8 +73,8 @@ var (
 			},
 		},
 		Relationships: map[string]string{
-			"db":    "",
-			"mysql": "",
+			"db":    "postgresql",
+			"mysql": "mysql",
 		},
 		HasGit: true,
 		Services: []Service{
@@ -124,7 +124,7 @@ var (
 			},
 		},
 		Relationships: map[string]string{
-			"mysql": "",
+			"mysql": "mysql",
 		},
 		HasGit: true,
 		Services: []Service{

--- a/platformifier/templates/generic/.platform.app.yaml
+++ b/platformifier/templates/generic/.platform.app.yaml
@@ -20,7 +20,7 @@ type: "{{ .Type }}"
 {{ if .Relationships -}}
 relationships:
   {{ range $key, $value := .Relationships }}
-  {{- $key }}: "{{ $value }}"
+  {{- $key }}:
   {{ end -}}
 {{ else }}
 # relationships:

--- a/platformifier/templates/generic/.platform.app.yaml
+++ b/platformifier/templates/generic/.platform.app.yaml
@@ -24,7 +24,7 @@ relationships:
   {{ end -}}
 {{ else }}
 # relationships:
-#   database: "db:postgresql"
+#   db:
 {{ end }}
 
 # The size of the persistent disk of the application (in MB). Minimum value is 128.

--- a/platformifier/templates/upsun/.upsun/config.yaml
+++ b/platformifier/templates/upsun/.upsun/config.yaml
@@ -22,14 +22,10 @@ applications:
     relationships:
       {{ range $key, $value := .Relationships }}
       {{- $key }}:
-        service: "{{ $key }}"
-        endpoint: "{{ $value }}"
       {{ end -}}
     {{ else }}
     # relationships:
-    #   database:
-    #     service: db
-    #     endpoint: postgresql
+    #   database: "db:postgresql"
     {{ end }}
 
     # Mounts define directories that are writable after the build is complete.

--- a/platformifier/templates/upsun/.upsun/config.yaml
+++ b/platformifier/templates/upsun/.upsun/config.yaml
@@ -25,7 +25,7 @@ applications:
       {{ end -}}
     {{ else }}
     # relationships:
-    #   database: "db:postgresql"
+    #   db:
     {{ end }}
 
     # Mounts define directories that are writable after the build is complete.

--- a/validator/schema/platformsh.application.json
+++ b/validator/schema/platformsh.application.json
@@ -45,7 +45,25 @@
     "relationships": {
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "service": {
+                "type": "string"
+              },
+              "endpoint": {
+                "type": "string"
+              }
+            }
+          }
+        ]
       },
       "title": "The relationships of the application to defined services.",
       "default": {}
@@ -373,9 +391,28 @@
         "relationships": {
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "service": {
+                    "type": "string"
+                  },
+                  "endpoint": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
           },
-          "title": "The relationships of the application to defined services."
+          "title": "The relationships of the application to defined services.",
+          "default": {}
         },
         "access": {
           "type": "object",
@@ -762,9 +799,28 @@
           "relationships": {
             "type": "object",
             "additionalProperties": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "service": {
+                      "type": "string"
+                    },
+                    "endpoint": {
+                      "type": "string"
+                    }
+                  }
+                }
+              ]
             },
-            "title": "The relationships of the application to defined services."
+            "title": "The relationships of the application to defined services.",
+            "default": {}
           },
           "access": {
             "type": "object",

--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -49,6 +49,9 @@
                   "type": "string"
                 },
                 {
+                  "type": "null"
+                },
+                {
                   "type": "object",
                   "properties": {
                     "service": {
@@ -57,8 +60,7 @@
                     "endpoint": {
                       "type": "string"
                     }
-                  },
-                  "nullable": true
+                  }
                 }
               ]
             },
@@ -384,9 +386,28 @@
               "relationships": {
                 "type": "object",
                 "additionalProperties": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "service": {
+                          "type": "string"
+                        },
+                        "endpoint": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
                 },
-                "title": "The relationships of the application to defined services."
+                "title": "The relationships of the application to defined services.",
+                "default": {}
               },
               "access": {
                 "type": "object",
@@ -769,9 +790,28 @@
                 "relationships": {
                   "type": "object",
                   "additionalProperties": {
-                    "type": "string"
+                    "oneOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "service": {
+                            "type": "string"
+                          },
+                          "endpoint": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
                   },
-                  "title": "The relationships of the application to defined services."
+                  "title": "The relationships of the application to defined services.",
+                  "default": {}
                 },
                 "access": {
                   "type": "object",
@@ -1277,6 +1317,9 @@
               "oneOf": [
                 {
                   "type": "string"
+                },
+                {
+                  "type": "null"
                 },
                 {
                   "type": "object",


### PR DESCRIPTION
Closes https://github.com/platformsh/platformify/issues/222

Updating Upsun and Platform.sh was a bit complicated for the tests and expected types. 

Currently:

- Upsun uses [explicit relationships](https://docs.platform.sh/create-apps/app-reference/single-runtime-image.html#relationships), but of incorrect format. (see issue linked above for details)
- Platform.sh uses legacy relationships

This PR (for now) updates both Platform.sh and Upsun platformify commands (when a service is chosen) to use the simplified relationships format. 