### PR TITLE
Remind install gunicorn in generated config

### DIFF
--- a/platformifier/templates/upsun/.upsun/config.yaml
+++ b/platformifier/templates/upsun/.upsun/config.yaml
@@ -55,6 +55,9 @@ applications:
       commands:
         # The command to launch your app. If it terminates, it’s restarted immediately.
         # You can use the $PORT or the $SOCKET environment variable depending on the socket family of your upstream
+        {{- if or ( eq .Stack "Django" ) ( eq .Stack "Flask" ) }}
+        # The command below assumes Gunicorn has been added as a dependency in your requirements.txt, Pipfile, or pyproject.toml file.
+        {{- end }}
         start: {{ quote .WebCommand }}
       {{- else }}
       # commands:


### PR DESCRIPTION
User feedback, hoping to make assumed start command more clear and avoid a first 502 push:

![CleanShot 2024-07-11 at 14 15 17](https://github.com/platformsh/platformify/assets/5473659/9a289796-c5b5-410a-8bc8-533040b6e28f)
