### PR TITLE
feature: use pipenv sync instead of install

### DIFF
--- a/internal/question/build_steps.go
+++ b/internal/question/build_steps.go
@@ -40,7 +40,7 @@ func (q *BuildSteps) Ask(ctx context.Context) error {
 				"# Install Pipenv as a global tool",
 				"python -m venv /app/.global",
 				"pip install pipenv==$PIPENV_TOOL_VERSION",
-				"pipenv install",
+				"pipenv sync",
 			)
 		case models.Pip:
 			answers.BuildSteps = append(

--- a/internal/question/environment.go
+++ b/internal/question/environment.go
@@ -18,10 +18,10 @@ func (q *Environment) Ask(ctx context.Context) error {
 	for _, dm := range answers.DependencyManagers {
 		switch dm {
 		case models.Poetry:
-			answers.Environment["POETRY_VERSION"] = "1.4.0"
+			answers.Environment["POETRY_VERSION"] = "1.8.4"
 			answers.Environment["POETRY_VIRTUALENVS_IN_PROJECT"] = "true"
 		case models.Pipenv:
-			answers.Environment["PIPENV_TOOL_VERSION"] = "2023.2.18"
+			answers.Environment["PIPENV_TOOL_VERSION"] = "2024.2.0"
 			answers.Environment["PIPENV_VENV_IN_PROJECT"] = "1"
 		}
 	}

--- a/platformifier/templates/django/settings_psh.py
+++ b/platformifier/templates/django/settings_psh.py
@@ -22,10 +22,7 @@ def decode(variable):
         JSON decoding error.
     """
     try:
-        if sys.version_info[1] > 5:
-            return json.loads(base64.b64decode(variable))
-        else:
-            return json.loads(base64.b64decode(variable).decode("utf-8"))
+        return json.loads(base64.b64decode(variable))
     except json.decoder.JSONDecodeError:
         print("Error decoding JSON, code %d", json.decoder.JSONDecodeError)
 


### PR DESCRIPTION
pipenv sync does installation by looking at the Pipfile.lock, and it verifies package hashed. It should be the prefered way to install packages in a deployment environment.