### PR TITLE
chore: update mounts and add post_start on schemas

### DIFF
--- a/validator/schema/platformsh.application.json
+++ b/validator/schema/platformsh.application.json
@@ -78,7 +78,8 @@
             "title": "The type of mount that will provide the data.",
             "enum": [
               "local",
-              "service"
+              "service",
+              "tmp"
             ]
           },
           "source_path": {
@@ -367,7 +368,8 @@
                 "title": "The type of mount that will provide the data.",
                 "enum": [
                   "local",
-                  "service"
+                  "service",
+                  "tmp"
                 ]
               },
               "source_path": {
@@ -560,6 +562,10 @@
             "start": {
               "type": "string",
               "title": "The command used to start the application.  It will be restarted if it terminates. Do not use on PHP unless using a custom persistent process like React PHP."
+            },
+            "post_start": {
+              "type": "string",
+              "title": "A command executed after the application is started."
             }
           },
           "required": [
@@ -774,7 +780,8 @@
                   "title": "The type of mount that will provide the data.",
                   "enum": [
                     "local",
-                    "service"
+                    "service",
+                    "tmp"
                   ]
                 },
                 "source_path": {

--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -76,8 +76,11 @@
                   "type": "string",
                   "title": "The type of mount that will provide the data.",
                   "enum": [
+                    "instance",
+                    "service",
                     "storage",
-                    "service"
+                    "temporary",
+                    "tmp"
                   ]
                 },
                 "source_path": {
@@ -361,8 +364,11 @@
                       "type": "string",
                       "title": "The type of mount that will provide the data.",
                       "enum": [
+                        "instance",
+                        "service",
                         "storage",
-                        "service"
+                        "temporary",
+                        "tmp"
                       ]
                     },
                     "source_path": {
@@ -764,8 +770,11 @@
                         "type": "string",
                         "title": "The type of mount that will provide the data.",
                         "enum": [
+                          "instance",
+                          "service",
                           "storage",
-                          "service"
+                          "temporary",
+                          "tmp"
                         ]
                       },
                       "source_path": {
@@ -849,6 +858,10 @@
                     "start": {
                       "type": "string",
                       "title": "The command used to start the application.  It will be restarted if it terminates. Do not use on PHP unless using a custom persistent process like React PHP."
+                    },
+                    "post_start": {
+                      "type": "string",
+                      "title": "A command executed after the application is started."
                     }
                   },
                   "required": [


### PR DESCRIPTION
mounts are different between [upsun][1] and [platformsh][2]

[1]: https://docs.upsun.com/create-apps/app-reference/single-runtime-image.html#define-a-mount
[2]: https://docs.platform.sh/create-apps/app-reference/single-runtime-image.html#define-a-mount

Failure:

```
+ upsun validate
Upsun config validation failed: applications.myapp.mounts.log.source: applications.myapp.mounts.log.source must be one of the following: "storage", "service"
applications.myapp.mounts.tmp.source: applications.myapp.mounts.tmp.source must be one of the following: "storage", "service"
```

with a valid mounts:

``` yaml
      mounts:
        "log":
          source: "tmp"
          source_path: "tmp"
        "storage":
          source: "storage"
          source_path: "storage"
        "tmp":
          source: "tmp"
          source_path: "tmp"
```

and add new post_start command