### PR TITLE
Remove enum variants from boolean fields in the Upsun JSON schema,

### DIFF
--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -114,11 +114,7 @@
               "enabled": {
                 "type": "boolean",
                 "title": "Whether the preflight security blocks are enabled",
-                "description": "Must be a boolean",
-                "enum": [
-                  true,
-                  false
-                ]
+                "description": "Must be a boolean"
               },
               "ignored_rules": {
                 "type": "array",
@@ -275,11 +271,7 @@
                     "allow": {
                       "type": "boolean",
                       "title": "Whether to allow serving files which don’t match a rule",
-                      "default": true,
-                      "enum": [
-                        true,
-                        false
-                      ]
+                      "default": true
                     },
                     "headers": {
                       "type": "object",
@@ -971,31 +963,19 @@
                 "type": "boolean",
                 "title": "Whether strict transport security is enabled or not",
                 "description": "If set to true, HSTS is enabled for 1 year.  \nIf set to false, other properties are ignored.",
-                "default": null,
-                "enum": [
-                  true,
-                  false
-                ]
+                "default": null
               },
               "include_subdomains": {
                 "type": "boolean",
                 "title": "Whether the strict transport security policy should include all subdomains",
                 "description": "More information: \nhttps://docs.upsun.com/define-routes/https.html#enable-http-strict-transport-security-hsts",
-                "default": false,
-                "enum": [
-                  true,
-                  false
-                ]
+                "default": false
               },
               "preload": {
                 "type": "boolean",
                 "title": "Whether the strict transport security policy should be preloaded in browsers",
                 "description": "To add your website to the HSTS preload list: \nhttps://hstspreload.org/. \nThanks to this list, most browsers are informed that your site requires HSTS before an HSTS header response is even issued.\n",
-                "default": false,
-                "enum": [
-                  true,
-                  false
-                ]
+                "default": false
               }
             },
             "additionalProperties": false,


### PR DESCRIPTION
The enum variants cause surprising validation errors in Zed.
![Screenshot 2025-06-02 at 11 04 59](https://github.com/user-attachments/assets/6e61ad0e-e007-4bb4-9b41-1c77dc7b2e5c)
