### PR TITLE
Authorise Nix channel in `type`

### DIFF
--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -712,7 +712,7 @@
             "description": "A list of packages from the Upsun collection of supported runtimes and/or from NixPkgs.  \nMore information: \nhttps://docs.upsun.com/create-apps/app-reference/composable-image.html"
           }
         },
-        "oneOf": [
+        "anyOf": [
           {
             "required": [
               "type"


### PR DESCRIPTION
As now, for Composable Image (`stack`) we can define the desired Nix Channel in the `type` setting, we need to authorise having both `stack` and `type` (and not one or the other)

cf. https://github.com/platformsh/platformsh-docs/pull/4623