### PR TITLE
Allow container_profiles property on workers

### DIFF
--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -642,6 +642,7 @@
                 },
                 "size": {"$ref": "#/definitions/deprecated/size"},
                 "resources": {"$ref": "#/definitions/deprecated/resources"},
+                "container_profile": {"$ref": "#/definitions/container_profile"},
                 "commands": {
                   "type": "object",
                   "properties": {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -216,6 +216,30 @@ applications:
 			wantErr: false,
 		},
 		{
+			name: "worker container profile",
+			args: args{
+				path: fstest.MapFS{
+					".upsun/config.yaml": &fstest.MapFile{
+						Data: []byte(`
+applications:
+  app1:
+    type: "python:3.11"
+    preflight:
+      enabled: true
+    workers:
+      app1-worker:
+        commands:
+          start: |
+            sleep 86400 && echo "done"
+        container_profile: HIGH_CPU
+`,
+						),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "false-boolean",
 			args: args{
 				path: fstest.MapFS{


### PR DESCRIPTION
Having a container_profile defined at the worker level is OK but the validator isn't allowing this.

This MR proposes to fix that.