### PR TITLE
fix(schema): require type for composable image stack in platformsh schema

### DIFF
--- a/validator/schema/platformsh.application.json
+++ b/validator/schema/platformsh.application.json
@@ -917,7 +917,7 @@
       ]
     }
   },
-  "oneOf": [
+  "anyOf": [
     {
       "required": [
         "name",
@@ -927,6 +927,7 @@
     {
       "required": [
         "name",
+        "type",
         "stack"
       ]
     }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -359,7 +359,7 @@ stack:
 		t.Run(tt.name, func(t *testing.T) {
 			dir := t.TempDir()
 			appFile := filepath.Join(dir, ".platform.app.yaml")
-			if err := os.WriteFile(appFile, []byte(tt.appYAML), 0600); err != nil {
+			if err := os.WriteFile(appFile, []byte(tt.appYAML), 0o600); err != nil {
 				t.Fatalf("failed to write .platform.app.yaml: %v", err)
 			}
 			if err := validatePlatformConfig(dir); (err != nil) != tt.wantErr {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -2,6 +2,8 @@ package validator
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 )
@@ -302,6 +304,66 @@ applications:
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateUpsunConfig(tt.args.path); (err != nil) != tt.wantErr {
 				t.Errorf("validateUpsunConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_validatePlatformConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		appYAML string
+		wantErr bool
+	}{
+		{
+			name: "simple",
+			appYAML: `
+name: app1
+type: "python:3.11"
+`,
+			wantErr: false,
+		},
+		{
+			name: "missing name and type",
+			appYAML: `
+web:
+  commands:
+    start: echo "start"
+`,
+			wantErr: true,
+		},
+		{
+			name: "stack with type",
+			appYAML: `
+name: app1
+type: "composable:25.05"
+stack:
+  - "php@8.3"
+  - "nodejs@20"
+`,
+			wantErr: false,
+		},
+		{
+			name: "stack without type",
+			appYAML: `
+name: app1
+stack:
+  - "php@8.3"
+  - "nodejs@20"
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			appFile := filepath.Join(dir, ".platform.app.yaml")
+			if err := os.WriteFile(appFile, []byte(tt.appYAML), 0600); err != nil {
+				t.Fatalf("failed to write .platform.app.yaml: %v", err)
+			}
+			if err := validatePlatformConfig(dir); (err != nil) != tt.wantErr {
+				t.Errorf("validatePlatformConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Mirrors the upsun.json change from #258 to `platformsh.application.json`: `type` is now required when using composable image `stack`
- Switches the top-level `oneOf` to `anyOf` so documents with both `type` and `stack` validate correctly (with `oneOf`, both branches would be satisfied simultaneously, causing a validation error)
- Adds `Test_validatePlatformConfig` with cases for: simple type-only app, missing required fields, stack with type (valid), and stack without type (error)

## Test plan

- [x] `stack with type` passes validation
- [x] `stack without type` fails validation
- [x] All existing tests still pass