### PR TITLE
feat: add image property to application schema for external:0.2 OCI type

### DIFF
--- a/validator/schema/upsun.json
+++ b/validator/schema/upsun.json
@@ -38,6 +38,19 @@
             "title": "Composable Image definition",
             "description": "A list of packages from the Upsun collection of supported runtimes and/or from NixPkgs.  \nMore information: \nhttps://docs.upsun.com/anchors/app/composable/"
           },
+          "image": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "OCI container image name",
+                "description": "The container image URI (e.g. \"gotenberg/gotenberg:latest\") for applications using type: external:0.2."
+              }
+            },
+            "additionalProperties": false,
+            "title": "OCI container image",
+            "description": "Container image configuration for external applications (type: external:0.2).  \nMore information: \nhttps://docs.upsun.com/anchors/app/reference/type/"
+          },
           "source": {
             "type": "object",
             "properties": {
@@ -732,6 +745,7 @@
         "x-order": [
           "type",
           "stack",
+          "image",
           "source",
           "resources",
           "relationships",

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -298,6 +298,38 @@ applications:
 			},
 			wantErr: true,
 		},
+		{
+			name: "external-oci-image",
+			args: args{
+				path: fstest.MapFS{
+					".upsun/config.yaml": &fstest.MapFile{
+						Data: []byte(`
+applications:
+  app:
+    type: "nodejs:24"
+    web:
+      commands:
+        start: node server.js
+      locations:
+        /:
+          passthru: true
+    relationships:
+      gotenberg: {}
+  gotenberg:
+    type: "external:0.2"
+    image:
+      name: "gotenberg/gotenberg:latest"
+routes:
+  https://{default}/:
+    type: upstream
+    upstream: app:http
+`,
+						),
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds `image` property (object with `name` string) to the application schema in `upsun.json`
- Adds `image` to the `x-order` list after `stack`
- Adds a test case `external-oci-image` covering an app + Gotenberg OCI service configuration

## Context

Applications using `type: external:0.2` require an `image.name` property to specify the OCI container image (e.g. `gotenberg/gotenberg:latest`). Without this fix, `upsun lint` rejects the config with:

```
applications.<name>: Additional property image is not allowed
```

## Test plan

- [x] New test `external-oci-image` fails before the schema change
- [x] All 15 tests pass after the schema change (`go test ./validator/...`)